### PR TITLE
chore(cloud-init): truncate hostnames in determineHostname

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -283,6 +284,14 @@ func determineHostname(md datasource.Metadata, udata *initialize.UserData) strin
 		udataHostname := udata.FindHostname()
 		if udataHostname != "" {
 			hostname = udataHostname
+		}
+	}
+	if len(hostname) > 63 {
+		log.Printf("Hostname too long. Truncating hostname %s to %s", hostname, strings.Split(hostname, ".")[0])
+		hostname = strings.Split(hostname, ".")[0]
+		if len(hostname) > 63 {
+			log.Printf("Hostname still too long. Truncating hostname %s further to 63 bytes (%s)", hostname, hostname[:63])
+			hostname = hostname[:63]
 		}
 	}
 	return hostname

--- a/datasource/metadata/ec2/metadata.go
+++ b/datasource/metadata/ec2/metadata.go
@@ -78,11 +78,6 @@ func (ms metadataService) FetchMetadata() (datasource.Metadata, error) {
 	}
 
 	if hostname, err := ms.fetchAttribute(fmt.Sprintf("%s/hostname", ms.MetadataUrl())); err == nil {
-		hostname := strings.Split(hostname, ".")[0]
-		if len(hostname) > 63 {
-			log.Printf("Truncating hostname %s to 63 bytes (%s)", hostname, hostname[:63])
-			hostname = hostname[:63]
-		}
 		metadata.Hostname = hostname
 	} else if _, ok := err.(pkg.ErrNotFound); !ok {
 		return metadata, err

--- a/datasource/metadata/ec2/metadata_test.go
+++ b/datasource/metadata/ec2/metadata_test.go
@@ -188,25 +188,7 @@ func TestFetchMetadata(t *testing.T) {
 				"/2009-04-04/meta-data/public-keys/0/openssh-key": "key",
 			},
 			expect: datasource.Metadata{
-				Hostname:      "host",
-				PrivateIPv4:   net.ParseIP("1.2.3.4"),
-				PublicIPv4:    net.ParseIP("5.6.7.8"),
-				SSHPublicKeys: map[string]string{"test1": "key"},
-			},
-		},
-		{
-			root:         "/",
-			metadataPath: "2009-04-04/meta-data",
-			resources: map[string]string{
-				"/2009-04-04/meta-data/hostname":                  "this-hostname-is-larger-than-sixty-three-characters-long-and-will-be-truncated.local",
-				"/2009-04-04/meta-data/local-ipv4":                "1.2.3.4",
-				"/2009-04-04/meta-data/public-ipv4":               "5.6.7.8",
-				"/2009-04-04/meta-data/public-keys":               "0=test1\n",
-				"/2009-04-04/meta-data/public-keys/0":             "openssh-key",
-				"/2009-04-04/meta-data/public-keys/0/openssh-key": "key",
-			},
-			expect: datasource.Metadata{
-				Hostname:      "this-hostname-is-larger-than-sixty-three-characters-long-and-wi",
+				Hostname:      "host.local",
 				PrivateIPv4:   net.ParseIP("1.2.3.4"),
 				PublicIPv4:    net.ParseIP("5.6.7.8"),
 				SSHPublicKeys: map[string]string{"test1": "key"},


### PR DESCRIPTION
# truncate too long hostnames

Long hostnames can have unexpected consequences and this makes the truncation behavior explicit

This also cleans up existing truncating in AWS

## How to use

A new node that uses cloud init and has an overly long host name.

Technically the second case should never happen, because most cloud providers are attempting to block direct instance names longer than 63 chars, but rather safe than sorry.

## Testing done

Test added for
* truncate on first `.`
* truncate at 63 chars if segment before first `.` is still too long

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

This is an alternative to #30

In this suggestion, all truncation happens centrally instead of for each metadata service. This reduces code duplication.
